### PR TITLE
Allow different in- and outputs for Resolvers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,8 +5,8 @@ import getMongoDbUpdate from './src/mongoDbUpdate';
 import GraphQLPaginationType from './src/graphQLPaginationType';
 import getGraphQLSortType from './src/graphQLSortType';
 import getMongoDbProjection from './src/mongoDbProjection';
-import { getMongoDbQueryResolver, getGraphQLQueryArgs } from './src/queryResolver';
-import { getMongoDbUpdateResolver, getGraphQLUpdateArgs } from './src/updateResolver';
+import { getMongoDbQueryResolver, getGraphQLQueryArgs, QueryOptions } from './src/queryResolver';
+import {getMongoDbUpdateResolver, getGraphQLUpdateArgs, UpdateOptions} from './src/updateResolver';
 import { setLogger } from './src/logger';
 
 export {
@@ -18,8 +18,10 @@ export {
     GraphQLPaginationType,
     getGraphQLSortType,
     getMongoDbProjection,
+    QueryOptions,
     getMongoDbQueryResolver,
     getGraphQLQueryArgs,
+    UpdateOptions,
     getMongoDbUpdateResolver,
     getGraphQLUpdateArgs,
     setLogger

--- a/index.ts
+++ b/index.ts
@@ -1,26 +1,26 @@
-import { getGraphQLFilterType } from './src/graphQLFilterType';
+import {getGraphQLFilterType} from './src/graphQLFilterType';
 import getMongoDbFilter from './src/mongoDbFilter';
-import { getGraphQLUpdateType, getGraphQLInsertType } from './src/graphQLMutationType';
+import {getGraphQLUpdateType, getGraphQLInsertType} from './src/graphQLMutationType';
 import getMongoDbUpdate from './src/mongoDbUpdate';
 import GraphQLPaginationType from './src/graphQLPaginationType';
 import getGraphQLSortType from './src/graphQLSortType';
 import getMongoDbProjection from './src/mongoDbProjection';
-import { getMongoDbQueryResolver, getGraphQLQueryArgs } from './src/queryResolver';
-import { getMongoDbUpdateResolver, getGraphQLUpdateArgs } from './src/updateResolver';
-import { setLogger } from './src/logger';
+import {getMongoDbQueryResolver, getGraphQLQueryArgs} from './src/queryResolver';
+import {getMongoDbUpdateResolver, getGraphQLUpdateArgs} from './src/updateResolver';
+import {setLogger} from './src/logger';
 
-export { 
-    getGraphQLFilterType, 
-    getMongoDbFilter,
-    getGraphQLUpdateType, 
-    getGraphQLInsertType, 
-    getMongoDbUpdate, 
-    GraphQLPaginationType, 
-    getGraphQLSortType, 
-    getMongoDbProjection,
-    getMongoDbQueryResolver,
-    getGraphQLQueryArgs,
-    getMongoDbUpdateResolver,
-    getGraphQLUpdateArgs,
-    setLogger
+export {
+  getGraphQLFilterType,
+  getMongoDbFilter,
+  getGraphQLUpdateType,
+  getGraphQLInsertType,
+  getMongoDbUpdate,
+  GraphQLPaginationType,
+  getGraphQLSortType,
+  getMongoDbProjection,
+  getMongoDbQueryResolver,
+  getGraphQLQueryArgs,
+  getMongoDbUpdateResolver,
+  getGraphQLUpdateArgs,
+  setLogger,
 };

--- a/index.ts
+++ b/index.ts
@@ -1,26 +1,26 @@
-import {getGraphQLFilterType} from './src/graphQLFilterType';
+import { getGraphQLFilterType } from './src/graphQLFilterType';
 import getMongoDbFilter from './src/mongoDbFilter';
-import {getGraphQLUpdateType, getGraphQLInsertType} from './src/graphQLMutationType';
+import { getGraphQLUpdateType, getGraphQLInsertType } from './src/graphQLMutationType';
 import getMongoDbUpdate from './src/mongoDbUpdate';
 import GraphQLPaginationType from './src/graphQLPaginationType';
 import getGraphQLSortType from './src/graphQLSortType';
 import getMongoDbProjection from './src/mongoDbProjection';
-import {getMongoDbQueryResolver, getGraphQLQueryArgs} from './src/queryResolver';
-import {getMongoDbUpdateResolver, getGraphQLUpdateArgs} from './src/updateResolver';
-import {setLogger} from './src/logger';
+import { getMongoDbQueryResolver, getGraphQLQueryArgs } from './src/queryResolver';
+import { getMongoDbUpdateResolver, getGraphQLUpdateArgs } from './src/updateResolver';
+import { setLogger } from './src/logger';
 
 export {
-  getGraphQLFilterType,
-  getMongoDbFilter,
-  getGraphQLUpdateType,
-  getGraphQLInsertType,
-  getMongoDbUpdate,
-  GraphQLPaginationType,
-  getGraphQLSortType,
-  getMongoDbProjection,
-  getMongoDbQueryResolver,
-  getGraphQLQueryArgs,
-  getMongoDbUpdateResolver,
-  getGraphQLUpdateArgs,
-  setLogger,
+    getGraphQLFilterType,
+    getMongoDbFilter,
+    getGraphQLUpdateType,
+    getGraphQLInsertType,
+    getMongoDbUpdate,
+    GraphQLPaginationType,
+    getGraphQLSortType,
+    getMongoDbProjection,
+    getMongoDbQueryResolver,
+    getGraphQLQueryArgs,
+    getMongoDbUpdateResolver,
+    getGraphQLUpdateArgs,
+    setLogger
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-to-mongodb",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Allows for generic run-time generation of filter types for existing graphql types and parsing client requests to mongodb find queries",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/queryResolver.ts
+++ b/src/queryResolver.ts
@@ -18,14 +18,14 @@ export interface QueryCallback<TSource, TContext> {
     ): Promise<any>
 }
 
-export function getMongoDbQueryResolver<TSource, TContext>(graphQLType: GraphQLObjectType, queryCallback: QueryCallback<TSource, TContext>)
+export function getMongoDbQueryResolver<TSource, TContext>(graphQLType: GraphQLObjectType, queryCallback: QueryCallback<TSource, TContext>, differentOutputType: boolean = false)
     : GraphQLFieldResolver<TSource, TContext> {
     if (!isType(graphQLType)) throw 'getMongoDbQueryResolver must recieve a graphql type'
     if (typeof queryCallback !== 'function') throw 'getMongoDbQueryResolver must recieve a queryCallback function'
 
     return async (source: TSource, args: { [argName: string]: any }, context: TContext, info: GraphQLResolveInfo): Promise<any> => {
         const filter = getMongoDbFilter(graphQLType, args.filter);
-        const projection = getMongoDbProjection(info.fieldNodes, graphQLType);
+        const projection = differentOutputType ? null : getMongoDbProjection(info.fieldNodes,graphQLType);
         const options: { sort?: object, limit?: number, skip?: number } = {};
         if (args.sort) options.sort = clear(args.sort, FICTIVE_SORT);
         if (args.pagination && args.pagination.limit) options.limit = args.pagination.limit;

--- a/src/updateResolver.ts
+++ b/src/updateResolver.ts
@@ -18,7 +18,7 @@ export interface UpdateCallback<TSource, TContext> {
     ): Promise<any>
 }
 
-export function getMongoDbUpdateResolver<TSource, TContext>(graphQLType: GraphQLObjectType, updateCallback: UpdateCallback<TSource, TContext>)
+export function getMongoDbUpdateResolver<TSource, TContext>(graphQLType: GraphQLObjectType, updateCallback: UpdateCallback<TSource, TContext>, differentOutputType: boolean = true)
     : GraphQLFieldResolver<TSource, TContext> {
     if (!isType(graphQLType)) throw 'getMongoDbUpdateResolver must recieve a graphql type';
     if (typeof updateCallback !== 'function') throw 'getMongoDbUpdateResolver must recieve an updateCallback';
@@ -26,8 +26,7 @@ export function getMongoDbUpdateResolver<TSource, TContext>(graphQLType: GraphQL
     return async (source: TSource, args: { [argName: string]: any }, context: TContext, info: GraphQLResolveInfo): Promise<any> => {
         const filter = getMongoDbFilter(graphQLType, args.filter);
         const mongoUpdate = getMongoDbUpdate(args.update);
-        const projection = getMongoDbProjection(info.fieldNodes, graphQLType);
-        
+        const projection = differentOutputType ? null : getMongoDbProjection(info.fieldNodes, graphQLType);
         return await updateCallback(filter, mongoUpdate.update, mongoUpdate.options, projection, source, args, context, info);
     };
 }


### PR DESCRIPTION
To allow different in and output parameters, I added an parameter with default to disable the projection generation.

I think it should be disabled by default in the `getMongoDbUpdateResolver` because in most cases you will only return the acknowledgement from MongoDB like in the following example:

``` javascript
const ExampleUpdate = {
  id: 'example', // prefix 'update_' will be added
  type: AcknowledgeType,
  args: getGraphQLUpdateArgs(ExampleType),
  resolve: getMongoDbUpdateResolver(
    ExampleType,
    async (filter, update, options, projection, source, args, context, info) => {
      const result = await context.db.collection('example').updateMany(filter, update, options);
      return result.result;
    },
    true
  )
};
```