### PR TITLE
Allow qraphql-to-mongodb work with custom scalar types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "homepage": "https://github.com/Soluto/graphql-to-mongodb#readme",
   "devDependencies": {
     "@types/graphql": "^0.12.4"
+    "@types/mongodb": "^2.2.0"
   },
   "peerDependencies": {
-    "graphql": ">=0.10"
+    "graphql": ">=0.10",
+    "mongodb": ">=2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "graphql-to-mongodb",
-  "version": "1.3.4",
+  "name": "@prinzdezibel/graphql-to-mongodb",
+  "version": "1.3.6",
   "description": "Allows for generic run-time generation of filter types for existing graphql types and parsing client requests to mongodb find queries",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -20,10 +20,8 @@
   "homepage": "https://github.com/Soluto/graphql-to-mongodb#readme",
   "devDependencies": {
     "@types/graphql": "^0.12.4"
-    "@types/mongodb": "^2.2.0"
   },
   "peerDependencies": {
-    "graphql": ">=0.10",
-    "mongodb": ">=2.2"
+    "graphql": ">=0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@prinzdezibel/graphql-to-mongodb",
-  "version": "1.3.6",
+  "name": "graphql-to-mongodb",
+  "version": "1.3.4",
   "description": "Allows for generic run-time generation of filter types for existing graphql types and parsing client requests to mongodb find queries",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/mongoDbFilter.ts
+++ b/src/mongoDbFilter.ts
@@ -1,4 +1,3 @@
-import { ObjectId } from 'mongodb';
 import { isType, GraphQLScalarType, GraphQLEnumType, GraphQLType, GraphQLObjectType } from 'graphql';
 import { getTypeFields, getInnerType, isListType, isScalarType } from './common';
 import { warn, logOnError } from './logger';
@@ -70,10 +69,10 @@ function parseMongoDbFilter(type: GraphQLObjectType, graphQLFilter: object, path
         }));
 }
 
-// GraphQLObjectType
-function parseMongoDbFieldFilter(type: any, fieldFilter: object, path: string[], ...excludedFields: string[]): object {
+function parseMongoDbFieldFilter(type: GraphQLObjectType, fieldFilter: object, path: string[], ...excludedFields: string[]): object {
     if (isScalarType(type)) {
-        const elementFilter = parseMongoDbScalarFilter(type as GraphQLScalarType, fieldFilter);
+        const scalarType: GraphQLScalarType = <any>type;
+        const elementFilter = parseMongoDbScalarFilter(scalarType, fieldFilter);
 
         return Object.keys(elementFilter).length > 0
             ? { [path.join(".")]: elementFilter }

--- a/src/mongoDbFilter.ts
+++ b/src/mongoDbFilter.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb';
 import { isType, GraphQLScalarType, GraphQLEnumType, GraphQLType, GraphQLObjectType } from 'graphql';
 import { getTypeFields, getInnerType, isListType, isScalarType } from './common';
 import { warn, logOnError } from './logger';
@@ -71,7 +72,7 @@ function parseMongoDbFilter(type: GraphQLObjectType, graphQLFilter: object, path
 
 function parseMongoDbFieldFilter(type: GraphQLObjectType, fieldFilter: object, path: string[], ...excludedFields: string[]): object {
     if (isScalarType(type)) {
-        const elementFilter = parseMongoDbScalarFilter(fieldFilter);
+        const elementFilter = parseMongoDbScalarFilter(type, fieldFilter);
 
         return Object.keys(elementFilter).length > 0
             ? { [path.join(".")]: elementFilter }
@@ -87,7 +88,7 @@ function parseMongoExistsFilter(exists: string): object {
 
 let dperecatedMessageSent = false;
 
-function parseMongoDbScalarFilter(graphQLFilter: object): object {
+function parseMongoDbScalarFilter(type: GraphQLObjectType, graphQLFilter: object): object {
     const mongoDbScalarFilter = {};
 
     Object.keys(graphQLFilter)
@@ -109,7 +110,8 @@ function parseMongoDbScalarFilter(graphQLFilter: object): object {
                 }
                 ///////////////////////////////////////////////////////////////////
             } else {
-                mongoDbScalarFilter[operatorsMongoDbKeys[key]] = element;
+                const value = type.name === 'ObjID' ? new ObjectId(element) : element;
+                mongoDbScalarFilter[operatorsMongoDbKeys[key]] = value;
 
                 if (key === 'REGEX' && graphQLFilter['OPTIONS']) {
                     mongoDbScalarFilter[operatorsMongoDbKeys['OPTIONS']] = graphQLFilter['OPTIONS'];


### PR DESCRIPTION
Imagine an application that uses a custom scalar type. For example, let's consider a type that can deal with mongodb's ObjectId:
```
export default {
  ObjID: new GraphQLScalarType({
    name: 'ObjID',
    description: 'Id string representation of MongoDB Object Ids',
    parseValue(value) {
      return ObjectId(value);
    },
    serialize(value) {
      return value.toString();
    },
    parseLiteral(ast) {
      if (ast.kind === Kind.STRING) {
        return ObjectId(ast.value);
      }
      return null;
    }
  })
}
```

Further imagine there's a document in mongodb with the following layout:
```
{
    "_id" : ObjectId("5ad61317a1b460007404645c"),
    "name": "A mongodb document"
}
```

Now if one pipes the following graphql query through graphql-to-mongodb:

` _id: { EQ: "5ad61317a1b460007404645c" } }`

the resulting mongo query would be:

` { _id: { $eq: "5ad61317a1b460007404645c" } }`

which would not work as expected.

With this PR applied, the resulting query would correctly be transformed to:
`{ _id: { $eq: ObjectId("5ad61317a1b460007404645c" ) } }`