### PR TITLE
lowercase enum value

### DIFF
--- a/src/mongoDbFilter.ts
+++ b/src/mongoDbFilter.ts
@@ -124,7 +124,7 @@ function parseMongoDbFilter(type: GraphQLFieldsType, graphQLFilter: GraphQLObjec
 }
 
 function parseMongoExistsFilter(exists: 'exists' | 'not_exists'): { $exists: boolean } {
-    return { $exists: exists === 'exists' ? true : false };
+    return { $exists: typeof exists === 'string' && exists.trim().toLowerCase() === 'exists' };
 }
 
 function parseMongoDbLeafFilter(graphQLLeafFilter: GraphQLLeafFilter, not: boolean = false): MongoDbLeafFilter {


### PR DESCRIPTION
Was testing this module with Apollo and noticed that my `EXISTS` enum value was translating to `$exists: false`; after some digging I found out that the value that reached the compare function was `EXISTS` so it was always false.